### PR TITLE
fix: allow false values to be used as substitutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For example, if you want to test a XML API response containing static data and v
 </xml>
 ```
 
-The property `"appVersion"` can change anytime and to avoid updating it every time, use `setSubstitutions`:
+The property `"appVersion"` can change anytime and to avoid updating it every time, use `setSubstitutions` method to replace it with a string (or a value that can be casted to string) of your choice:
 
 ```php
 class FooSnapshot extends DynamicSnapshot

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,11 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.16@d03e5ef057d6adc656c0ff7e166c50b73b4f48f3">
   <file src="src/Fkupper/Codeception/DynamicSnapshot.php">
-    <MixedArgument occurrences="3">
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_object($value)</code>
+      <code>is_scalar($value)</code>
+    </DocblockTypeContradiction>
+    <MixedArgument occurrences="4">
       <code>$this-&gt;dataSet</code>
       <code>$this-&gt;dataSet</code>
       <code>$this-&gt;dataSet</code>
+      <code>$value</code>
     </MixedArgument>
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>!is_scalar($value) || (is_object($value) &amp;&amp; !method_exists($value, '__toString'))</code>
+      <code>$value !== null</code>
+      <code>is_scalar($value)</code>
+      <code>return $value !== null;</code>
+    </RedundantConditionGivenDocblockType>
     <UnusedClass occurrences="1">
       <code>DynamicSnapshot</code>
     </UnusedClass>

--- a/src/Fkupper/Codeception/DynamicSnapshot.php
+++ b/src/Fkupper/Codeception/DynamicSnapshot.php
@@ -201,13 +201,19 @@ abstract class DynamicSnapshot extends Snapshot
     }
 
     /**
-     * Replaces the real values in the snpashot by the keys.
+     * Replaces the real values in the snapshot by the keys.
      *
      * @return void
      */
     protected function replaceRealValues(): void
     {
-        if (count($this->substitutions) !== count(array_filter($this->substitutions))) {
+        $actual_substitutions = array_filter(
+            $this->substitutions,
+            function ($value) {
+                return $value !== null;
+            }
+        );
+        if (count($this->substitutions) !== count($actual_substitutions)) {
             $this->fail('Error while saving snapshot: one or more substitutions is empty.');
         }
 

--- a/src/Fkupper/Codeception/DynamicSnapshot.php
+++ b/src/Fkupper/Codeception/DynamicSnapshot.php
@@ -4,6 +4,7 @@ namespace Fkupper\Codeception;
 
 use Codeception\Exception\ContentNotFound;
 use Codeception\Snapshot;
+use InvalidArgumentException;
 
 abstract class DynamicSnapshot extends Snapshot
 {
@@ -74,7 +75,13 @@ abstract class DynamicSnapshot extends Snapshot
     public function setSubstitutions(array $substitutions): void
     {
         foreach ($substitutions as $key => $value) {
-            $this->substitutions[$this->substitutionPrefix . $key] = $value;
+            if (!is_scalar($value) || (is_object($value) && !method_exists($value, '__toString'))) {
+                throw new InvalidArgumentException(
+                    'Substitutions can only be string values or values that can be casted to string. ' .
+                    "You provided substitution `$key` of type " . getType($value)
+                );
+            }
+            $this->substitutions[$this->substitutionPrefix . $key] = (string)$value;
         }
     }
 
@@ -207,13 +214,7 @@ abstract class DynamicSnapshot extends Snapshot
      */
     protected function replaceRealValues(): void
     {
-        $actual_substitutions = array_filter(
-            $this->substitutions,
-            function ($value) {
-                return $value !== null;
-            }
-        );
-        if (count($this->substitutions) !== count($actual_substitutions)) {
+        if (count($this->substitutions) !== count(array_filter($this->substitutions))) {
             $this->fail('Error while saving snapshot: one or more substitutions is empty.');
         }
 

--- a/tests/unit/DynamicSnapshotTest.php
+++ b/tests/unit/DynamicSnapshotTest.php
@@ -155,4 +155,61 @@ class DynamicSnapshotTest extends Unit
             $mock->cleanContent($value)
         );
     }
+
+    /**
+     * @test
+     * @covers \Fkupper\Codeception\DynamicSnapshot::setSubstitutions
+     * @dataProvider provideInvalidSubstitutions
+     */
+    public function itWillNotAllowUnsupportedSubstitutions(array $substitutions)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Substitutions can only be string values or values that can be casted to string. ' .
+            'You provided substitution `element` of type ' . getType($substitutions['element'])
+        );
+        $mock = Mockery::mock(DynamicSnapshot::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $mock->setSubstitutions($substitutions);
+    }
+
+    public function provideInvalidSubstitutions()
+    {
+        return [
+            'object_with_no_to_string_method' => [[
+                'element' => new stdClass(),
+            ]],
+            'nested_array' => [[
+                'element' => [],
+            ]],
+        ];
+    }
+
+    /**
+     * @test
+     * @covers \Fkupper\Codeception\DynamicSnapshot::setSubstitutions
+     * @dataProvider provideValidSubstitutions
+     */
+    public function itWillAllowSupportedSubstitutions(array $substitutions)
+    {
+        $mock = Mockery::mock(DynamicSnapshot::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $mock->setSubstitutions($substitutions);
+    }
+
+    public function provideValidSubstitutions()
+    {
+        return [
+            'string' => [[
+                'element' => 'John Snow',
+            ]],
+            'int' => [[
+                'element' => 2,
+            ]],
+        ];
+    }
 }


### PR DESCRIPTION
I've noticed that `false` values make the assertion fail, because they're filtered out in `replaceRealValues`. 

This change would make it possible to use them in assertions, while still filtering `null` values. It'd look nicer with
short function syntax, but that'd violate the php version constraint from composer.

I'm still trying to figure out how to write a test for it without mocking half of the lib.