### PR TITLE
feature: v3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.4', '8.0']
+        php: ['8.0', '8.1']
 
     steps:
     - name: checkout

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,14 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": "^7.4 || ^8.0",
-        "codeception/codeception": "^4.0",
-        "codeception/module-asserts": "^1.0.0"
+        "php": "^8.0",
+        "codeception/codeception": "^4.1"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.5",
-        "vimeo/psalm": "^3.16",
-        "mockery/mockery": "^1.3",
-        "php-coveralls/php-coveralls": "^2.3"
+        "squizlabs/php_codesniffer": "^3.7",
+        "vimeo/psalm": "^4.27",
+        "mockery/mockery": "^1.5",
+        "php-coveralls/php-coveralls": "^2.5"
     },
     "autoload": {
         "classmap": [

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
   <file src="src/Fkupper/Codeception/DynamicSnapshot.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_object($value)</code>
       <code>is_object($value)</code>
     </DocblockTypeContradiction>
     <InternalClass occurrences="1"/>
@@ -9,10 +10,12 @@
       <code>getComparisonFailure</code>
       <code>new ContentNotFound("Fetched dynamic snapshot is empty.")</code>
     </InternalMethod>
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="6">
       <code>$this-&gt;dataSet</code>
       <code>$this-&gt;dataSet</code>
       <code>$this-&gt;dataSet</code>
+      <code>$this-&gt;dataSet</code>
+      <code>$value</code>
       <code>$value</code>
     </MixedArgument>
     <UnusedClass occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.16@d03e5ef057d6adc656c0ff7e166c50b73b4f48f3">
+<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
   <file src="src/Fkupper/Codeception/DynamicSnapshot.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction occurrences="1">
       <code>is_object($value)</code>
-      <code>is_scalar($value)</code>
     </DocblockTypeContradiction>
+    <InternalClass occurrences="1"/>
+    <InternalMethod occurrences="3">
+      <code>getComparisonFailure</code>
+      <code>new ContentNotFound("Fetched dynamic snapshot is empty.")</code>
+    </InternalMethod>
     <MixedArgument occurrences="4">
       <code>$this-&gt;dataSet</code>
       <code>$this-&gt;dataSet</code>
       <code>$this-&gt;dataSet</code>
       <code>$value</code>
     </MixedArgument>
-    <RedundantConditionGivenDocblockType occurrences="4">
-      <code>!is_scalar($value) || (is_object($value) &amp;&amp; !method_exists($value, '__toString'))</code>
-      <code>$value !== null</code>
-      <code>is_scalar($value)</code>
-      <code>return $value !== null;</code>
-    </RedundantConditionGivenDocblockType>
     <UnusedClass occurrences="1">
       <code>DynamicSnapshot</code>
     </UnusedClass>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
@@ -12,5 +12,5 @@
         </ignoreFiles>
         <directory name="src/Fkupper/Codeception"/>
     </projectFiles>
-    
+
 </psalm>

--- a/src/Fkupper/Codeception/DynamicSnapshot.php
+++ b/src/Fkupper/Codeception/DynamicSnapshot.php
@@ -72,7 +72,7 @@ abstract class DynamicSnapshot extends Snapshot
                     "You provided substitution `$key` of type " . getType($value)
                 );
             }
-            $substitutionKey = $this->getSubstitutionKey((string)$key, strictSubstitutions: false);
+            $substitutionKey = $this->getSubstitutionKey($key, strictSubstitutions: false);
             $this->substitutions[$substitutionKey] = (string)$value;
         }
     }
@@ -83,7 +83,7 @@ abstract class DynamicSnapshot extends Snapshot
      * Strict substitutions are checked using boundaries in the regex.
      * Eg:
      * ['user_id' => 99, 'day_of_the_week' => 6]
-     * @param array<string,scalar|object> $strictSubstitutions
+     * @param array<string, scalar|object> $strictSubstitutions
      */
     public function setStrictSubstitutions(array $strictSubstitutions): void
     {
@@ -94,7 +94,7 @@ abstract class DynamicSnapshot extends Snapshot
                     "You provided substitution `$key` of type " . getType($value)
                 );
             }
-            $substitutionKey = $this->getSubstitutionKey((string)$key, strictSubstitutions: true);
+            $substitutionKey = $this->getSubstitutionKey($key, strictSubstitutions: true);
             $this->strictSubstitutions[$substitutionKey] = (string)$value;
         }
     }
@@ -223,12 +223,14 @@ abstract class DynamicSnapshot extends Snapshot
         return $data;
     }
 
-    protected function replaceRealValueWithPlaceholder(string $value, string $placeholder, bool $withBoundaries = false): void
-    {
+    protected function replaceRealValueWithPlaceholder(
+        string $value,
+        string $placeholder,
+        bool $withBoundaries = false
+    ): void {
         $value = preg_quote($value, '/');
         $placeholder = $this->quoteAndWrap($placeholder);
         $regex = $withBoundaries ? "/\b$value\b/" : "/$value/";
-        info(dump($regex));
         $this->dataSet = preg_replace($regex, $placeholder, $this->dataSet);
     }
 
@@ -301,7 +303,8 @@ abstract class DynamicSnapshot extends Snapshot
         try {
             $substitutions = [];
             foreach ($this->strictSubstitutions as $key => $value) {
-                $substitutions[str_replace($this->strictSubstitutionPrefix, '', $key)] = OutputFormatter::escape($value);
+                $substitutionKey = str_replace($this->strictSubstitutionPrefix, '', $key);
+                $substitutions[$substitutionKey] = OutputFormatter::escape($value);
             }
             $output = 'Strict substitutions:' . PHP_EOL . print_r($substitutions, true);
         } catch (Throwable $t) {

--- a/src/Fkupper/Codeception/DynamicSnapshot.php
+++ b/src/Fkupper/Codeception/DynamicSnapshot.php
@@ -242,10 +242,7 @@ abstract class DynamicSnapshot extends Snapshot
         return $data;
     }
 
-    /**
-     * @return string
-     */
-    protected function getSubstitutionsOutput()
+    protected function getSubstitutionsOutput(): string
     {
         $output = '';
         try {
@@ -263,6 +260,7 @@ abstract class DynamicSnapshot extends Snapshot
 
     /**
      * Performs assertion for data sets
+     * @return void
      */
     public function assert()
     {

--- a/src/Fkupper/Codeception/DynamicSnapshot.php
+++ b/src/Fkupper/Codeception/DynamicSnapshot.php
@@ -5,41 +5,31 @@ namespace Fkupper\Codeception;
 use Codeception\Exception\ContentNotFound;
 use Codeception\Snapshot;
 use InvalidArgumentException;
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Throwable;
 
 abstract class DynamicSnapshot extends Snapshot
 {
-    /** @var string */
-    protected $leftWrapper = '[';
+    protected string $leftWrapper = '[';
+    protected string $rightWrapper = ']';
+    protected string $substitutionPrefix = 'snapshot_';
+    protected string $strictSubstitutionPrefix = 'snapshot_strict_';
 
-    /** @var string */
-    protected $rightWrapper = ']';
-
-    /** @var string */
-    protected $substitutionPrefix = 'snapshot_';
+    protected bool $allowTrailingSpaces = false;
+    protected bool $allowSpaceSequences = false;
 
     /** @var array<string,string> */
-    protected $substitutions = [];
-
+    protected array $substitutions = [];
+    /** @var array<string,string> */
+    protected array $strictSubstitutions = [];
     /** @var array<string> */
-    protected $ignoredLinesPatters = [];
+    protected array $ignoredLinesPatters = [];
 
-    /** @var bool */
-    protected $allowTrailingSpaces = false;
-
-    /** @var bool */
-    protected $allowSpaceSequences = false;
 
     /**
      * Set what charaters will be used to wrap substitution keys.
      * Default is []
-     *
-     * @param string $leftWrapper = '['
-     * @param string $rightWrapper = ']'
-     * @return void
      */
     public function setWrappers(string $leftWrapper = '[', string $rightWrapper = ']'): void
     {
@@ -51,20 +41,19 @@ abstract class DynamicSnapshot extends Snapshot
         $this->rightWrapper = $rightWrapper;
     }
 
-    /**
-     * @return string
-     */
     protected function getLeftWrapper(): string
     {
         return $this->leftWrapper;
     }
 
-    /**
-     * @return string
-     */
     protected function getRightWrapper(): string
     {
         return $this->rightWrapper;
+    }
+
+    protected function getSubstitutionKey(string $key, bool $strictSubstitutions): string
+    {
+        return ($strictSubstitutions ? $this->strictSubstitutionPrefix : $this->substitutionPrefix) . $key;
     }
 
     /**
@@ -72,9 +61,7 @@ abstract class DynamicSnapshot extends Snapshot
      * replacement as the values.
      * Eg:
      * ['user_id' => '99', 'some_dynamic_path' => '/foo/path/123/']
-     *
      * @param array<string,scalar|object> $substitutions
-     * @return void
      */
     public function setSubstitutions(array $substitutions): void
     {
@@ -85,16 +72,37 @@ abstract class DynamicSnapshot extends Snapshot
                     "You provided substitution `$key` of type " . getType($value)
                 );
             }
-            $this->substitutions[$this->substitutionPrefix . $key] = (string)$value;
+            $substitutionKey = $this->getSubstitutionKey((string)$key, strictSubstitutions: false);
+            $this->substitutions[$substitutionKey] = (string)$value;
+        }
+    }
+
+    /**
+     * Sets the array of strict substitutions containing keys as the keys and the
+     * replacement as the values.
+     * Strict substitutions are checked using boundaries in the regex.
+     * Eg:
+     * ['user_id' => 99, 'day_of_the_week' => 6]
+     * @param array<string,scalar|object> $strictSubstitutions
+     */
+    public function setStrictSubstitutions(array $strictSubstitutions): void
+    {
+        foreach ($strictSubstitutions as $key => $value) {
+            if (!is_scalar($value) || (is_object($value) && !method_exists($value, '__toString'))) {
+                throw new InvalidArgumentException(
+                    'Strict substitutions can only be string values or values that can be casted to string. ' .
+                    "You provided substitution `$key` of type " . getType($value)
+                );
+            }
+            $substitutionKey = $this->getSubstitutionKey((string)$key, strictSubstitutions: true);
+            $this->strictSubstitutions[$substitutionKey] = (string)$value;
         }
     }
 
     /**
      * Sets an array of regex patterns that will be used to remove lines that matches them
      * both from expected and actual snapshot value.
-     *
      * @param array<string> $patterns
-     * @return void
      */
     public function setIgnoredLinesPatterns(array $patterns): void
     {
@@ -103,9 +111,7 @@ abstract class DynamicSnapshot extends Snapshot
 
     /**
      * Allows trailing spaces in snapshots.
-     *
      * @param bool $allowTrailingSpaces
-     * @return void
      */
     public function shouldAllowTrailingSpaces(bool $allowTrailingSpaces = true): void
     {
@@ -119,9 +125,7 @@ abstract class DynamicSnapshot extends Snapshot
 
     /**
      * Allows whitespace sequences in snapshots.
-     *
      * @param bool $allowSpaceSequences
-     * @return void
      */
     public function shouldAllowSpaceSequences(bool $allowSpaceSequences = true): void
     {
@@ -140,7 +144,8 @@ abstract class DynamicSnapshot extends Snapshot
     {
         $this->dataSet = $this->removeIgnoredLines($this->dataSet);
         $this->dataSet = $this->cleanContent($this->dataSet);
-        $this->replaceRealValues();
+        $this->replaceRealValuesWithStrictPlaceholders();
+        $this->replaceRealValuesWithPlaceholders();
         parent::save();
     }
 
@@ -150,6 +155,7 @@ abstract class DynamicSnapshot extends Snapshot
     protected function load()
     {
         parent::load();
+        $this->applyStrictSubstitutions();
         $this->applySubstitutions();
     }
 
@@ -165,9 +171,7 @@ abstract class DynamicSnapshot extends Snapshot
 
     /**
      * Apply shouldAllowSpaceSequences and shouldAllowTrailingSpaces rules
-     *
      * @param string $data
-     * @return string
      */
     protected function cleanContent(string $data): string
     {
@@ -184,23 +188,31 @@ abstract class DynamicSnapshot extends Snapshot
     }
 
     /**
-     * Replaces values with placeholder keys.
-     *
+     * Replaces placeholders with real values using boundaries.
+     * @see setStrictSubstitutions
+     */
+    protected function applyStrictSubstitutions(): void
+    {
+        foreach ($this->strictSubstitutions as $placeholder => $value) {
+            $placeholder = $this->wrapAndQuote($placeholder);
+            $this->dataSet = preg_replace("/\b$placeholder\b/", $value, $this->dataSet);
+        }
+    }
+
+    /**
+     * Replaces placeholders with real values using boundaries.
      * @see setSubstitutions
-     * @return void
      */
     protected function applySubstitutions(): void
     {
-        foreach ($this->substitutions as $pattern => $replacement) {
-            $pattern = $this->wrapAndQuote($pattern);
-            $this->dataSet = preg_replace("/$pattern/", $replacement, $this->dataSet);
+        foreach ($this->substitutions as $placeholder => $value) {
+            $placeholder = $this->wrapAndQuote($placeholder);
+            $this->dataSet = preg_replace("/$placeholder/", $value, $this->dataSet);
         }
     }
 
     /**
      * Removes ignored lines defined by setIgnoredLinesPatterns.
-     *
-     * @return string
      */
     protected function removeIgnoredLines(string $data): string
     {
@@ -211,21 +223,40 @@ abstract class DynamicSnapshot extends Snapshot
         return $data;
     }
 
+    protected function replaceRealValueWithPlaceholder(string $value, string $placeholder, bool $withBoundaries = false): void
+    {
+        $value = preg_quote($value, '/');
+        $placeholder = $this->quoteAndWrap($placeholder);
+        $regex = $withBoundaries ? "/\b$value\b/" : "/$value/";
+        info(dump($regex));
+        $this->dataSet = preg_replace($regex, $placeholder, $this->dataSet);
+    }
+
     /**
-     * Replaces the real values in the snapshot by the keys.
-     *
-     * @return void
+     * Replaces the real values in the snapshot with placeholders using boundaries `\b`.
      */
-    protected function replaceRealValues(): void
+    protected function replaceRealValuesWithStrictPlaceholders(): void
+    {
+        if (count($this->strictSubstitutions) !== count(array_filter($this->strictSubstitutions))) {
+            $this->fail('Error while saving snapshot: one or more strict substitutions is empty.');
+        }
+
+        foreach ($this->strictSubstitutions as $placeholder => $value) {
+            $this->replaceRealValueWithPlaceholder($value, $placeholder, withBoundaries: true);
+        }
+    }
+
+    /**
+     * Replaces the real values in the snapshot with placeholders.
+     */
+    protected function replaceRealValuesWithPlaceholders(): void
     {
         if (count($this->substitutions) !== count(array_filter($this->substitutions))) {
             $this->fail('Error while saving snapshot: one or more substitutions is empty.');
         }
 
-        foreach ($this->substitutions as $pattern => $replacement) {
-            $replacement = preg_quote($replacement, '/');
-            $pattern = $this->quoteAndWrap($pattern);
-            $this->dataSet = preg_replace("/$replacement/", $pattern, $this->dataSet);
+        foreach ($this->substitutions as $placeholder => $value) {
+            $this->replaceRealValueWithPlaceholder($value, $placeholder);
         }
     }
 
@@ -245,6 +276,9 @@ abstract class DynamicSnapshot extends Snapshot
     protected function getSubstitutionsOutput(): string
     {
         $output = '';
+        if (count($this->substitutions) === 0) {
+            return $output;
+        }
         try {
             $substitutions = [];
             foreach ($this->substitutions as $key => $value) {
@@ -253,6 +287,25 @@ abstract class DynamicSnapshot extends Snapshot
             $output = 'Substitutions:' . PHP_EOL . print_r($substitutions, true);
         } catch (Throwable $t) {
             $output = 'Count not get substitutions output. Failed with error: ' . $t->getMessage();
+        } finally {
+            return PHP_EOL . PHP_EOL . $output . PHP_EOL;
+        }
+    }
+
+    protected function getStrictSubstitutionsOutput(): string
+    {
+        $output = '';
+        if (count($this->strictSubstitutions) === 0) {
+            return $output;
+        }
+        try {
+            $substitutions = [];
+            foreach ($this->strictSubstitutions as $key => $value) {
+                $substitutions[str_replace($this->strictSubstitutionPrefix, '', $key)] = OutputFormatter::escape($value);
+            }
+            $output = 'Strict substitutions:' . PHP_EOL . print_r($substitutions, true);
+        } catch (Throwable $t) {
+            $output = 'Count not get strict substitutions output. Failed with error: ' . $t->getMessage();
         } finally {
             return PHP_EOL . PHP_EOL . $output . PHP_EOL;
         }
@@ -269,7 +322,8 @@ abstract class DynamicSnapshot extends Snapshot
         } catch (ExpectationFailedException $exception) {
             if ($this->showDiff) {
                 $substitutionsOutput = $this->getSubstitutionsOutput();
-                $message = $exception->getMessage() . $substitutionsOutput;
+                $strictSubstitutionsOutput = $this->getStrictSubstitutionsOutput();
+                $message = $exception->getMessage() . $substitutionsOutput . $strictSubstitutionsOutput;
                 throw new ExpectationFailedException(
                     $message,
                     $exception->getComparisonFailure(),

--- a/tests/unit/DynamicSnapshotTest.php
+++ b/tests/unit/DynamicSnapshotTest.php
@@ -216,6 +216,39 @@ class DynamicSnapshotTest extends Unit
 
     /**
      * @test
+     * @covers \Fkupper\Codeception\DynamicSnapshot::setStrictSubstitutions
+     * @dataProvider provideInvalidSubstitutions
+     */
+    public function itWillNotAllowUnsupportedStrictSubstitutions(array $substitutions)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Strict substitutions can only be string values or values that can be casted to string. ' .
+            'You provided substitution `element` of type ' . getType($substitutions['element'])
+        );
+        $mock = Mockery::mock(DynamicSnapshot::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $mock->setStrictSubstitutions($substitutions);
+    }
+
+    /**
+     * @test
+     * @covers \Fkupper\Codeception\DynamicSnapshot::setStrictSubstitutions
+     * @dataProvider provideValidSubstitutions
+     */
+    public function itWillAllowSupportedStrictSubstitutions(array $substitutions)
+    {
+        $mock = Mockery::mock(DynamicSnapshot::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $mock->setStrictSubstitutions($substitutions);
+    }
+
+    /**
+     * @test
      * @covers \Fkupper\Codeception\DynamicSnapshot::getSubstitutionsOutput
      */
     public function itCanGetSubstitutionsOutput()
@@ -237,6 +270,29 @@ class DynamicSnapshotTest extends Unit
         $this->assertSame(
             $expectedOutput,
             $actualOutput
+        );
+    }
+
+    /**
+     * @test
+     * @covers \Fkupper\Codeception\DynamicSnapshot::getSubstitutionKey
+     */
+    public function itCanGetSubstitutionKey()
+    {
+        $mock = Mockery::mock(DynamicSnapshot::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $actualKey = $mock->getSubstitutionKey('foo', false);
+        $this->assertSame(
+            'snapshot_foo',
+            $actualKey,
+        );
+
+        $actualStrictKey = $mock->getSubstitutionKey('foo', true);
+        $this->assertSame(
+            'snapshot_strict_foo',
+            $actualStrictKey,
         );
     }
 }


### PR DESCRIPTION
### PHP Version

* Removed support for php 7
* Added php 8.1 checks on CI

### Strict substitutions

Added a new feature for cases when substitution values are small numbers or character like `1`, `2`, or `a`. These substitutions should now be moved from `setSubstitutions` to `setStrictSubstitutions`, where they will be matched uses `\b` tokens, making cases like `http://some.url?some_id=1&some_other_id=12` not looking like `http://some.url?some_id=[snapshot_id_attribute]&some_other_id=[snapshot_id_attribute]2`.