### PR TITLE
chore: upgrade codeception to v5 (and test with PHP 8.0-8.2)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,8 +29,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer install --prefer-dist --no-progress
-        composer require "codeception/codeception:${{ matrix.codeception }}" --no-interaction --no-update
+        composer require "codeception/codeception:^${{ matrix.codeception }}" --no-interaction --no-update
+        composer update --prefer-dist --no-interaction --no-suggest
 
     - name: Run tests
       env:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.0', '8.1']
-        codeception: ['4.1', '5.0']
+        php: ['8.0', '8.1', '8.2']
+        codeception: ['5.0']
 
     steps:
-    - name: checkout
+    - name: Checkout
       uses: actions/checkout@v2
 
-    - name: setup php
+    - name: Setup php
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.0', '8.1']
+        codeception: ['4.1', '5.0']
 
     steps:
     - name: checkout
@@ -27,12 +28,14 @@ jobs:
       run: composer validate --strict
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+      run: |
+        composer install --prefer-dist --no-progress
+        composer require "codeception/codeception:${{ matrix.codeception }}" --no-interaction --no-update
 
     - name: Run tests
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.github_token }}
-        COVERALLS_FLAG_NAME: php-${{ matrix.php }}
+        COVERALLS_FLAG_NAME: php-${{ matrix.php }}-codeception-${{ matrix.codeception }}
         COVERALLS_PARALLEL: true
       run: composer check
 

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": "^8.0|^8.1",
-        "codeception/codeception": "^4.1|^5.0"
+        "php": "^8.0.|^8.1|^8.2",
+        "codeception/codeception": "^5.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fkupper/module-dynamic-snapshots",
-    "description": "Dynamic content shapshot testing for Codeception",
+    "description": "Dynamic content snapshot testing for Codeception",
     "keywords": [
         "codeception",
         "snapshot"
@@ -15,8 +15,8 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": "^8.0",
-        "codeception/codeception": "^4.1"
+        "php": "^8.0|^8.1",
+        "codeception/codeception": "^4.1|^5.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7",

--- a/src/Fkupper/Codeception/DynamicSnapshot.php
+++ b/src/Fkupper/Codeception/DynamicSnapshot.php
@@ -139,7 +139,7 @@ abstract class DynamicSnapshot extends Snapshot
 
     protected function save(): void
     {
-        $this->dataSet = $this->removeIgnoredLines($this->dataSet);
+        $this->dataSet = $this->removeIgnoredLines((string)$this->dataSet);
         $this->dataSet = $this->cleanContent($this->dataSet);
         $this->replaceRealValuesWithStrictPlaceholders();
         $this->replaceRealValuesWithPlaceholders();
@@ -187,7 +187,7 @@ abstract class DynamicSnapshot extends Snapshot
     {
         foreach (array_merge($this->substitutions, $this->strictSubstitutions) as $placeholder => $value) {
             $placeholder = $this->wrapAndQuote($placeholder);
-            $this->dataSet = preg_replace("/$placeholder/", $value, $this->dataSet);
+            $this->dataSet = preg_replace("/$placeholder/", $value, (string)$this->dataSet);
         }
     }
 
@@ -211,7 +211,7 @@ abstract class DynamicSnapshot extends Snapshot
         $value = preg_quote($value, '/');
         $placeholder = $this->quoteAndWrap($placeholder);
         $regex = $withBoundaries ? "/\b$value\b/" : "/$value/";
-        $this->dataSet = preg_replace($regex, $placeholder, $this->dataSet);
+        $this->dataSet = preg_replace($regex, $placeholder, (string)$this->dataSet);
     }
 
     /**

--- a/src/Fkupper/Codeception/DynamicSnapshot.php
+++ b/src/Fkupper/Codeception/DynamicSnapshot.php
@@ -28,7 +28,7 @@ abstract class DynamicSnapshot extends Snapshot
 
 
     /**
-     * Set what charaters will be used to wrap substitution keys.
+     * Set what characters will be used to wrap substitution keys.
      * Default is []
      */
     public function setWrappers(string $leftWrapper = '[', string $rightWrapper = ']'): void
@@ -137,10 +137,7 @@ abstract class DynamicSnapshot extends Snapshot
         return $this->allowSpaceSequences;
     }
 
-    /**
-     * @return void
-     */
-    protected function save()
+    protected function save(): void
     {
         $this->dataSet = $this->removeIgnoredLines($this->dataSet);
         $this->dataSet = $this->cleanContent($this->dataSet);
@@ -149,10 +146,7 @@ abstract class DynamicSnapshot extends Snapshot
         parent::save();
     }
 
-    /**
-     * @return void
-     */
-    protected function load()
+    protected function load(): void
     {
         parent::load();
         $this->applyAllSubstitutions();
@@ -170,7 +164,6 @@ abstract class DynamicSnapshot extends Snapshot
 
     /**
      * Apply shouldAllowSpaceSequences and shouldAllowTrailingSpaces rules
-     * @param string $data
      */
     protected function cleanContent(string $data): string
     {
@@ -249,7 +242,7 @@ abstract class DynamicSnapshot extends Snapshot
         }
     }
 
-    protected function fetchData()
+    protected function fetchData(): array|string|false
     {
         $data = $this->fetchDynamicData();
         if (!$data) {
@@ -301,11 +294,7 @@ abstract class DynamicSnapshot extends Snapshot
         }
     }
 
-    /**
-     * Performs assertion for data sets
-     * @return void
-     */
-    public function assert()
+    public function assert(): void
     {
         try {
             parent::assert();
@@ -325,8 +314,6 @@ abstract class DynamicSnapshot extends Snapshot
 
     /**
      * Should return dynamic data from current test run
-     *
-     * @return string
      */
-    abstract protected function fetchDynamicData();
+    abstract protected function fetchDynamicData(): string;
 }

--- a/src/Fkupper/Command/GenerateDynamicSnapshot.php
+++ b/src/Fkupper/Command/GenerateDynamicSnapshot.php
@@ -2,8 +2,8 @@
 
 namespace Fkupper\Command;
 
-use Codeception\Command\Shared\Config;
-use Codeception\Command\Shared\FileSystem;
+use Codeception\Command\Shared\ConfigTrait;
+use Codeception\Command\Shared\FileSystemTrait;
 use Codeception\Configuration;
 use Codeception\CustomCommandInterface;
 use Fkupper\Lib\Generator\DynamicSnapshot as DynamicSnapshotGenerator;
@@ -23,10 +23,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GenerateDynamicSnapshot extends Command implements CustomCommandInterface
 {
-    use FileSystem;
-    use Config;
+    use FileSystemTrait;
+    use ConfigTrait;
 
-    public static function getCommandName()
+    public static function getCommandName(): string
     {
         return 'generate:dynamicsnapshot';
     }
@@ -40,15 +40,15 @@ class GenerateDynamicSnapshot extends Command implements CustomCommandInterface
         parent::configure();
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Generates empty DynamicSnapshot class';
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $suite = $input->getArgument('suite');
-        $class = $input->getArgument('dynamicsnapshot');
+        $suite = (string)$input->getArgument('suite');
+        $class = (string)$input->getArgument('dynamicsnapshot');
 
         if (!$class) {
             $class = $suite;
@@ -61,6 +61,8 @@ class GenerateDynamicSnapshot extends Command implements CustomCommandInterface
 
         if ($suite) {
             $suite = DIRECTORY_SEPARATOR . ucfirst($suite);
+        } else {
+            $suite = '';
         }
 
         $path = $this->createDirectoryFor(Configuration::supportDir() . 'Snapshot' . $suite, $class);

--- a/tests/unit/DynamicSnapshotTest.php
+++ b/tests/unit/DynamicSnapshotTest.php
@@ -2,7 +2,6 @@
 
 use Codeception\Test\Unit;
 use Fkupper\Codeception\DynamicSnapshot;
-use PHPUnit\Framework\ExpectationFailedException;
 
 class DynamicSnapshotTest extends Unit
 {


### PR DESCRIPTION
Codeception 5 required changes that make the module incompatible with v4 unfortunately ([see this CI run](https://github.com/fkupper/module-dynamic-snapshots/actions/runs/4223584375)). 

Updated code to match changes from parent module in v5.
Added PHP 8.1 and 8.2 to the testing matrix.
Added codeception version to the testing matrix, although, as mentioned v5 is not compatible with v4, but maybe it'd be useful later on.

**Thus, this is a breaking change.**