### PR TITLE
fix: make command compatible with Symfony 7

### DIFF
--- a/src/Fkupper/Command/GenerateDynamicSnapshot.php
+++ b/src/Fkupper/Command/GenerateDynamicSnapshot.php
@@ -45,7 +45,7 @@ class GenerateDynamicSnapshot extends Command implements CustomCommandInterface
         return 'Generates empty DynamicSnapshot class';
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $suite = (string)$input->getArgument('suite');
         $class = (string)$input->getArgument('dynamicsnapshot');


### PR DESCRIPTION
I'm migrating a project to Laravel 11, I'm facing this error with incompatible command declaration.

```
Fatal error: Declaration of Fkupper\Command\GenerateDynamicSnapshot::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /home/circleci/project/vendor/fkupper/module-dynamic-snapshots/src/Fkupper/Command/GenerateDynamicSnapshot.php on line 48
```